### PR TITLE
Allow HTTP requests by specifying URL as --api-domain when setting up

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ create configuration file
 
 Options:
   --ignore-ssl         ignore invalid SSL certificate from the GitLab API server
-  --api-domain <name>  domain name of GitLab API server (default: "gitlab.com")
+  --api-domain <name>  domain name or root URL of GitLab API server,
+                       specify root URL (without trailing slash) to use HTTP instead of HTTPS (default: "gitlab.com")
   --dir <path>         path to directory to save configuration file in (default: ".")
-  -h, --help           output usage information
+  -h, --help           display help for command
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-search",
-  "version": "1.0.0",
+  "version": "1.1.0-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-search",
-  "version": "1.0.0",
+  "version": "1.1.0-beta1",
   "scripts": {
     "build": "rimraf dist && bsb -make-world && ncc build lib/js/src/Main.bs.js --out dist",
     "start": "bsb -make-world -w",

--- a/src/Main.re
+++ b/src/Main.re
@@ -34,11 +34,13 @@ let setup = (args, options) => {
   let token = Belt.Array.getExn(args, 0);
 
   // options below has default values set in their definition so they always has a value
-  let dir = Belt.Option.getExn(Commander.getOption(options, "dir"));
-  let domain = Belt.Option.getExn(Commander.getOption(options, "apiDomain"));
+  let directory = Belt.Option.getExn(Commander.getOption(options, "dir"));
+  let domainOrRootUri =
+    Belt.Option.getExn(Commander.getOption(options, "apiDomain"));
   let ignoreSSL = Commander.getOptionAsBoolean(options, "ignoreSsl");
 
-  let configPath = Config.writeToFile({domain, token, ignoreSSL}, dir);
+  let configPath =
+    Config.writeToFile(~domainOrRootUri, ~ignoreSSL, ~token, ~directory);
   Print.successful(
     "Successfully wrote config to "
     ++ configPath
@@ -76,7 +78,7 @@ Commander.(
      )
   |> optionWithDefault(
        "--api-domain <name>",
-       "domain name of GitLab API server",
+       "domain name or root URL of GitLab API server,\nspecify root URL (without trailing slash) to use HTTP instead of HTTPS",
        Config.defaultDomain,
      )
   |> optionWithDefault(


### PR DESCRIPTION
When running a self hosted GitLab solution, there's a chance the GitLab API server is running HTTP instead of HTTPS.

That's what these changes allows, by trying to extract HTTP/HTTPS protocol out of the configured API domain. Majority could still just provide only the domain name, as that would make requests being sent over HTTPS.

Here's a trivial example of how that would look for when the GitLab API server is hosted at `my.self.hosted.gitlab.corp` over HTTP:

```
$ gitlab-search setup --api-domain=http://my.self.hosted.gitlab.corp <insert-token-here>
```

Fixes https://github.com/phillipj/gitlab-search/issues/11