### PR TITLE
Fetch more groups & projects when more than 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ Usage: setup [options] <personal-access-token>
 create configuration file
 
 Options:
-  --ignore-ssl         ignore invalid SSL certificate from the GitLab API server
-  --api-domain <name>  domain name or root URL of GitLab API server,
-                       specify root URL (without trailing slash) to use HTTP instead of HTTPS (default: "gitlab.com")
-  --dir <path>         path to directory to save configuration file in (default: ".")
-  -h, --help           display help for command
+  --ignore-ssl            ignore invalid SSL certificate from the GitLab API server
+  --api-domain <name>     domain name or root URL of GitLab API server,
+                          specify root URL (without trailing slash) to use HTTP instead of HTTPS (default: "gitlab.com")
+  --dir <path>            path to directory to save configuration file in (default: ".")
+  --concurrency <number>  limit the amount of concurrent HTTPS requests sent to GitLab when searching,
+                          useful when *many* projects are hosted on a small GitLab instance
+                          to avoid overwhelming the instance resulting in 502 errors (default: 25)
+  -h, --help              display help for command
 ```
 
 ## Debugging

--- a/src/Commander.re
+++ b/src/Commander.re
@@ -67,6 +67,9 @@ let action: ((array(string), actionFnOptions) => unit, t) => t =
 external getOption: (actionFnOptions, string) => option(string) = "";
 
 [@bs.get_index]
+external getOptionAsInt: (actionFnOptions, string) => option(int) = "";
+
+[@bs.get_index]
 external getOptionAsBoolean: (actionFnOptions, string) => option(bool) = "";
 
 /**
@@ -92,3 +95,31 @@ let getOptionAsBoolean = (actionFnOptions, optionName): bool => {
 external optionWithDefault: (string, string, string) => t = "option";
 [@bs.send.pipe: t] external parse: array(string) => t = "parse";
 [@bs.send.pipe: t] external version: string => t = "version";
+
+// commander.js' .option() also accepts a validator-function provided as the third argument,
+//                         if so, the forth argument is the default value, not the third as usual
+[@bs.send.pipe: t]
+external optionWithIntDefault: (string, string, string => int, int) => t =
+  "option";
+
+let optionWithIntDefault = (name, description, defaultValue) => {
+  optionWithIntDefault(
+    name,
+    description,
+    valueProvidedByEndUser =>
+      try (int_of_string(valueProvidedByEndUser)) {
+      | Failure(_) =>
+        Js.log(
+          "Invalid number value ("
+          ++ valueProvidedByEndUser
+          ++ ") provided to "
+          ++ name
+          ++ ", will be using "
+          ++ string_of_int(defaultValue)
+          ++ " instead.",
+        );
+        defaultValue;
+      },
+    defaultValue,
+  );
+};

--- a/src/Main.re
+++ b/src/Main.re
@@ -37,10 +37,18 @@ let setup = (args, options) => {
   let directory = Belt.Option.getExn(Commander.getOption(options, "dir"));
   let domainOrRootUri =
     Belt.Option.getExn(Commander.getOption(options, "apiDomain"));
+  let concurrency =
+    Belt.Option.getExn(Commander.getOptionAsInt(options, "concurrency"));
   let ignoreSSL = Commander.getOptionAsBoolean(options, "ignoreSsl");
 
   let configPath =
-    Config.writeToFile(~domainOrRootUri, ~ignoreSSL, ~token, ~directory);
+    Config.writeToFile(
+      ~domainOrRootUri,
+      ~ignoreSSL,
+      ~token,
+      ~directory,
+      ~concurrency,
+    );
   Print.successful(
     "Successfully wrote config to "
     ++ configPath
@@ -85,6 +93,11 @@ Commander.(
        "--dir <path>",
        "path to directory to save configuration file in",
        Config.defaultDirectory,
+     )
+  |> optionWithIntDefault(
+       "--concurrency <number>",
+       "limit the amount of concurrent HTTPS requests sent to GitLab when searching,\nuseful when *many* projects are hosted on a small GitLab instance\nto avoid overwhelming the instance resulting in 502 errors",
+       Config.defaultConcurrency,
      )
   |> action(setup)
 );


### PR DESCRIPTION
For bigger GitLab installation with more than 100 groups and/or projects we need to perform some pagination tricks, which is what these changes introduces.

Until now, we only fetched the first page of 100 groups and projects.

Luckily it's quite trivial for us as GitLab's magnificent API provides hypermedia links answering what's important for us:

- Are there more pages of results needing to be fetched?
- What's the URL of the next page?

Closes https://github.com/phillipj/gitlab-search/issues/14
Refs https://docs.gitlab.com/ee/api/README.html#pagination