### PR TITLE
Display `(archived)` next to project title when archived

### DIFF
--- a/src/GitLab.re
+++ b/src/GitLab.re
@@ -11,6 +11,7 @@ type project = {
   id: int,
   name: string,
   web_url: string,
+  archived: bool,
 };
 
 type searchFilter =
@@ -43,6 +44,7 @@ module Decode = {
     id: json |> field("id", int),
     name: json |> field("name", string),
     web_url: json |> field("web_url", string),
+    archived: json |> field("archived", bool),
   };
   let projects = json => json |> array(project);
 

--- a/src/Print.re
+++ b/src/Print.re
@@ -41,7 +41,9 @@ let searchResults =
           ++ highlightMatchedTerm(term, indentPreview(current.data))
         );
 
-      Js.log(bold(green(project.name ++ ":")));
+      let archivedInfo = project.archived ? bold(red(" (archived)")) : "";
+
+      Js.log(bold(green(project.name ++ archivedInfo ++ ":")));
       Js.log(formattedResults);
     },
   );


### PR DESCRIPTION
As knowing a project is archived is obviously very valuable.

### Before

<img width="800" alt="Screenshot 2021-04-03 at 23 48 04" src="https://user-images.githubusercontent.com/1231635/113492354-09e7d580-94d7-11eb-872d-3bffbc00ec69.png">


### After

<img width="809" alt="Screenshot 2021-04-03 at 23 43 14" src="https://user-images.githubusercontent.com/1231635/113492357-15d39780-94d7-11eb-9a54-96705083da96.png">


Refs https://github.com/phillipj/gitlab-search/issues/20