### PR TITLE
Add support for pushing into Docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
       DOCKER_USERNAME: "${{ secrets.docker_hub_username }}"
       DOCKER_PASSWORD: "${{ secrets.docker_hub_password }}"
     steps:
+      - uses: actions/checkout@v2
       - run: |
          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
          docker build -t gitlab-search .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,3 +18,15 @@ jobs:
         run: |
           npm ci
           npm run build
+  deploy-to-docker:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: "${{ secrets.docker_hub_username }}"
+      DOCKER_PASSWORD: "${{ secrets.docker_hub_password }}"
+    steps:
+      - echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - docker build -t gitlab-search .
+      - docker tag gitlab-search "${DOCKER_USERNAME}/gitlab-search:${{ github.sha }}"
+      - docker tag gitlab-search "${DOCKER_USERNAME}/gitlab-search:latest"
+      - docker push "${DOCKER_USERNAME}/gitlab-search:${{ github.sha }}"
+      - docker push "${DOCKER_USERNAME}/gitlab-search:latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,10 @@ jobs:
       DOCKER_USERNAME: "${{ secrets.docker_hub_username }}"
       DOCKER_PASSWORD: "${{ secrets.docker_hub_password }}"
     steps:
-      - echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
-      - docker build -t gitlab-search .
-      - docker tag gitlab-search "${DOCKER_USERNAME}/gitlab-search:${{ github.sha }}"
-      - docker tag gitlab-search "${DOCKER_USERNAME}/gitlab-search:latest"
-      - docker push "${DOCKER_USERNAME}/gitlab-search:${{ github.sha }}"
-      - docker push "${DOCKER_USERNAME}/gitlab-search:latest"
+      - run: |
+         echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+         docker build -t gitlab-search .
+         docker tag gitlab-search "${DOCKER_USERNAME}/gitlab-search:${{ github.sha }}"
+         docker tag gitlab-search "${DOCKER_USERNAME}/gitlab-search:latest"
+         docker push "${DOCKER_USERNAME}/gitlab-search:${{ github.sha }}"
+         docker push "${DOCKER_USERNAME}/gitlab-search:latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
           npm run build
   deploy-to-docker:
     runs-on: ubuntu-latest
+    needs:
+      - build
     env:
       DOCKER_USERNAME: "${{ secrets.docker_hub_username }}"
       DOCKER_PASSWORD: "${{ secrets.docker_hub_password }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:14
+LABEL maintainer="Carlos Nunez <dev@carlosnunez.me>"
+
+COPY . /app
+WORKDIR /app
+RUN npm ci && npm run build && npm -g install
+ENTRYPOINT [ "gitlab-search" ]


### PR DESCRIPTION
This pull requests adds a Dockerfile as well as a Github Actions job to push its resultant Docker image into Docker Hub.

You can enable this by adding the following secrets to your repository settings:

- `push_to_docker`: Can be any value
- `docker_hub_username`: Your Docker Hub username
- `docker_hub_password`: Your Docker Hub password